### PR TITLE
send files and message/embed simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,22 @@ webhook.execute()
 ```
 ![Image](https://cdn.discordapp.com/attachments/480439896478187550/481041687020306432/unknown.png "Example Files Result")
 
+You can use uploaded attachments in embeds:
+```python
+from discord_webhook import DiscordWebhook, DiscordEmbed
+
+webhook = DiscordWebhook(url='your webhook url')
+
+with open("path/to/image.jpg", "rb") as f:
+    webhook.add_file(file=f.read(), filename='example.jpg')
+
+embed = DiscordEmbed(title='Embed Title', description='Your Embed Description', color=242424)
+embed.set_thumbnail(url='attachment://example.jpg')
+
+webhook.add_embed(embed)
+webhook.execute()
+```
+
 ### use proxies
 
 ```python


### PR DESCRIPTION
When sending files you can pass message/embed payload in `payload_json` field. [Documentation](https://discordapp.com/developers/docs/resources/channel#create-message-example-request-bodies-multipartformdata)
So now we need to prefix every file field name with `_` so file named `payload_json` doesn't interfere with the real payload. You never know what someone wants to send so better safe than sorry.
And finally we use `(filename, file)` format for files to let Discrod know what filename we want.

With that last bit we could use any random name for field name but keeping it prefixed with `_` allows us to replace files if we add two with the same filename, which was previous behaviour I didn't want to change.

And now you can use attachments in embeds.