### PR TITLE
Added ability to edit webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ webhook = DiscordWebhook(url='your webhook url', content='Webhook content before
 sent_webhook = webhook.execute()
 webhook.content = 'After Edit'
 sleep(10)
-sent_webhook = webhook.edit_sent_webhook(sent_webhook)
+sent_webhook = webhook.edit(sent_webhook)
 ```
 
 ### delete webhook messages
@@ -163,7 +163,7 @@ from time import sleep
 webhook = DiscordWebhook(url='your webhook url', content='Webhook Content')
 sent_webhook = webhook.execute()
 sleep(10)
-webhook.delete_sent_webhook(sent_webhook)
+webhook.delete(sent_webhook)
 ```
 
 ### send files

--- a/README.md
+++ b/README.md
@@ -141,6 +141,29 @@ response = webhook.execute()
 
 ![Image](img/extended_embed3.png "Example Non-Inline Embed Result")
 
+### edit webhook messages
+
+```python
+from discord_webhook import DiscordWebhook
+
+webhook = DiscordWebhook(url='https://canary.discord.com/api/webhooks/<channel id>/<webhook token>', content='Before Edit')
+sent_webhook = webhook.execute()
+webhook.content = 'After Edit'
+sent_webhook = webhook.edit_sent_webhook(sent_webhook)
+```
+
+### delete webhook messages
+
+```python
+from discord_webhook import DiscordWebhook
+from time import sleep
+
+webhook = DiscordWebhook(url='https://canary.discord.com/api/webhooks/<channel id>/<webhook token>', content='Before Edit')
+sent_webhook = webhook.execute()
+sleep(10)
+webhook.delete_sent_webhook(sent_webhook)
+```
+
 ### send files
 
 ```python

--- a/README.md
+++ b/README.md
@@ -145,10 +145,12 @@ response = webhook.execute()
 
 ```python
 from discord_webhook import DiscordWebhook
+from time import sleep
 
-webhook = DiscordWebhook(url='https://canary.discord.com/api/webhooks/<channel id>/<webhook token>', content='Before Edit')
+webhook = DiscordWebhook(url='your webhook url', content='Webhook content before edit')
 sent_webhook = webhook.execute()
 webhook.content = 'After Edit'
+sleep(10)
 sent_webhook = webhook.edit_sent_webhook(sent_webhook)
 ```
 
@@ -158,7 +160,7 @@ sent_webhook = webhook.edit_sent_webhook(sent_webhook)
 from discord_webhook import DiscordWebhook
 from time import sleep
 
-webhook = DiscordWebhook(url='https://canary.discord.com/api/webhooks/<channel id>/<webhook token>', content='Before Edit')
+webhook = DiscordWebhook(url='your webhook url', content='Webhook Content')
 sent_webhook = webhook.execute()
 sleep(10)
 webhook.delete_sent_webhook(sent_webhook)

--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -143,6 +143,7 @@ class DiscordWebhook:
         """
         edits the webhook passed as a response
         only supports one webhook at a time
+        :param sent_webhook: webhook.execute() response
         :return: Another webhook response
         """
         url = self.url
@@ -173,7 +174,8 @@ class DiscordWebhook:
         """
         deletes the webhook passed as a response
         only supports one webhook at a time
-        :return: response
+        :param sent_webhook: webhook.execute() response
+        :return: Response
         """
         url = self.url
         previous_sent_message_id = json.loads(sent_webhook.content.decode('utf-8'))['id']

--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -139,7 +139,7 @@ class DiscordWebhook:
         self.sent_message_id = json.loads((responses[0] if len(responses) == 1 else responses).content.decode('utf-8'))['id']
         return responses[0] if len(responses) == 1 else responses
 
-    def edit_sent_webhook(self, sent_webhook):
+    def edit(self, sent_webhook):
         """
         edits the webhook passed as a response
         only supports one webhook at a time
@@ -170,7 +170,7 @@ class DiscordWebhook:
             )
         return response
 
-    def delete_sent_webhook(self, sent_webhook):
+    def delete(self, sent_webhook):
         """
         deletes the webhook passed as a response
         only supports one webhook at a time

--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -169,6 +169,17 @@ class DiscordWebhook:
             )
         return response
 
+    def delete_sent_webhook(self, sent_webhook):
+        """
+        deletes the webhook passed as a response
+        only supports one webhook at a time
+        :return: response
+        """
+        url = self.url
+        previous_sent_message_id = json.loads(sent_webhook.content.decode('utf-8'))['id']
+        response = requests.delete(url+'/messages/'+str(previous_sent_message_id), proxies=self.proxies)
+        return response
+
 class DiscordEmbed:
     """
     Discord Embed
@@ -350,4 +361,3 @@ class DiscordEmbed:
         :return: `self.fields`
         """
         return self.fields
-    


### PR DESCRIPTION
I have added another function in the DiscordWebhook object that takes a executed webhook and edits it with the current params. Here is a example:

```py
webhook = DiscordWebhook(url='https://canary.discord.com/api/webhooks/<channel id>/<webhook token>', content='Before Edit')
sent_webhook = webhook.execute()
webhook.content = 'After Edit'
sent_webhook = webhook.edit(sent_webhook)
```

This allows webhooks to be edited. Currently it only supports singular url's.

Although the ability to edit webhooks has not been documented in the api docs yet, discord staff have commented on how to do it. The route is like this: `@blueprint.route('/webhooks/<webhook_id>/<webhook_token>/messages/<message_id>', methods=['PATCH'])`

Please try it out!