### PR TITLE
allow for user to resend a webhook if being rate limited

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ install via pip: `pip install discord-webhook`
 ## Examples
 
 * [Basic Webhook](#basic-webhook)
-* [manage being rate limited](#manage-being-rate-limited)
+* [Manage Being Rate Limited](#manage-being-rate-limited)
 * [Multiple Webhook Urls](#multiple-webhook-urls)
 * [Embedded Content](#webhook-with-embedded-content)
 * [Edit Webhook Message](#edit-webhook-messages)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ install via pip: `pip install discord-webhook`
 ## Examples
 
 * [Basic Webhook](#basic-webhook)
+* [manage being rate limited](#manage-being-rate-limited)
 * [Multiple Webhook Urls](#multiple-webhook-urls)
 * [Embedded Content](#webhook-with-embedded-content)
 * [Edit Webhook Message](#edit-webhook-messages)
@@ -27,6 +28,18 @@ install via pip: `pip install discord-webhook`
 from discord_webhook import DiscordWebhook
 
 webhook = DiscordWebhook(url='your webhook url', content='Webhook Message')
+response = webhook.execute()
+```
+
+### manage being rate limited
+```python
+from discord_webhook import DiscordWebhook
+
+# if rate_limit_retry is True then in the event that you are being rate 
+# limited by Discord your webhook will automatically be sent once the 
+# rate limit has been lifted
+webhook = DiscordWebhook(url='your webhook url', rate_limit_retry=True,
+                         content='Webhook Message')
 response = webhook.execute()
 ```
 

--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -167,7 +167,7 @@ class DiscordWebhook:
                         response.content.decode('utf-8'))
                     wh_sleep = (int(errors['retry_after']) / 1000) + 0.15
                     time.sleep(wh_sleep)
-                    logger.debug(
+                    logger.error(
                         "Webhook rate limited: sleeping for {wh_sleep} "
                         "seconds...".format(
                             wh_sleep=wh_sleep

--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -39,6 +39,7 @@ class DiscordWebhook:
         self.proxies = kwargs.get("proxies")
         self.allowed_mentions = kwargs.get("allowed_mentions")
         self.timeout = kwargs.get("timeout")
+        self.rate_limit_retry = kwargs.get("rate_limit_retry")
 
     def add_file(self, file, filename):
         """
@@ -129,6 +130,19 @@ class DiscordWebhook:
         """
         self.files = {}
 
+    def api_post_request(self, url):
+        if bool(self.files) is False:
+            response = requests.post(url, json=self.json, proxies=self.proxies,
+                                     params={'wait': True},
+                                     timeout=self.timeout)
+        else:
+            self.files["payload_json"] = (None, json.dumps(self.json))
+            response = requests.post(url, files=self.files,
+                                     proxies=self.proxies,
+                                     timeout=self.timeout)
+
+        return response
+
     def execute(self, remove_embeds=False, remove_files=False):
         """
         executes the Webhook
@@ -140,17 +154,33 @@ class DiscordWebhook:
         urls_len = len(webhook_urls)
         responses = []
         for i, url in enumerate(webhook_urls):
-            if bool(self.files) is False:
-                response = requests.post(url, json=self.json, proxies=self.proxies, params={'wait': True}, timeout=self.timeout)
-            else:
-                self.files["payload_json"] = (None, json.dumps(self.json))
-                response = requests.post(url, files=self.files, proxies=self.proxies, timeout=self.timeout)
+            response = self.api_post_request(url)
             if response.status_code in [200, 204]:
                 logger.debug(
                     "[{index}/{length}] Webhook executed".format(
                         index=i+1, length=urls_len
                     )
                 )
+            elif response.status_code == 429 and self.rate_limit_retry:
+                while response.status_code == 429:
+                    errors = json.loads(
+                        response.content.decode('utf-8'))
+                    wh_sleep = (int(errors['retry_after']) / 1000) + 0.15
+                    time.sleep(wh_sleep)
+                    logger.debug(
+                        "Webhook rate limited: sleeping for {wh_sleep} "
+                        "seconds...".format(
+                            wh_sleep=wh_sleep
+                        )
+                    )
+                    response = self.api_post_request(url)
+                    if response.status_code in [200, 204]:
+                        logger.debug(
+                            "[{index}/{length}] Webhook executed".format(
+                                index=i + 1, length=urls_len
+                            )
+                        )
+                        break
             else:
                 logger.error(
                     "[{index}/{length}] Webhook status code {status_code}: {content}".format(

--- a/examples/manage_rate_limits.py
+++ b/examples/manage_rate_limits.py
@@ -1,0 +1,5 @@
+from discord_webhook import DiscordWebhook
+
+webhook = DiscordWebhook(url='your webhook url', rate_limit_retry=True,
+                         content='Webhook Message')
+response = webhook.execute()


### PR DESCRIPTION
allows a user to pass an optional boolean kwarg of rate_limit_retry. If the value
of the boolean is True, then the program will automatically attempt to
resend the webhook as per the value returned from the retry limit error
message of the Discord Webhook response until the webhook is sent
successfully.

Also refactored the sending of the execution of the post request to make
the code a little bit nicer for the purposes of this new feature.