### PR TITLE
add exception handling for colors that are out of range

### DIFF
--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -3,6 +3,7 @@ import json
 import time
 import datetime
 import requests
+from webhook_exceptions import *
 
 
 logger = logging.getLogger(__name__)
@@ -344,6 +345,9 @@ class DiscordEmbed:
             self.color = int(color, 16)
         else:
             self.color = color
+
+        if self.color not in range(0, 16777216):
+            raise ColourNotInRangeException(color)
 
     def set_footer(self, **kwargs):
         """

--- a/discord_webhook/webhook_exceptions.py
+++ b/discord_webhook/webhook_exceptions.py
@@ -1,0 +1,14 @@
+class ColourNotInRangeException(Exception):
+    """
+    A valid colour must take an integer value between 0 and 16777216 inclusive
+
+    This Exception will be raised when a colour is not in that range.
+    """
+
+    def __init__(self, color):
+        self.color = color
+
+    def __str__(self):
+        return repr('"{}" is not in valid range of colors. The valid ranges '
+                    'of colors are 0 to 16777215 inclusive (INTEGERS) and 0 '
+                    'to FFFFFF inclusive (HEXADECIMAL)'.format(self.color))


### PR DESCRIPTION
This commit allows for an exception to be raised if a color for an embed is not in the correct range. 

I feel that this package is a little light on exception handling (especially for the embeds), and I intend to add a lot more exception handling to it, but this commit serves the purpose of seeing what you all think of this style of message.