### PR TITLE
Added async support (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,3 +336,31 @@ try:
 except Timeout as err:
     print(f'Oops! Connection to Discord timed out: {err}')
 ```
+
+
+### async support
+In order to use the async version, you need to install the package using:
+```
+pip install discord-webhook[async]
+```
+Example usage:
+```python
+import asyncio
+from discord_webhook import AsyncDiscordWebhook
+
+
+async def send_webhook(message):
+    webhook = AsyncDiscordWebhook(url='your webhook url',
+                                  content=message)
+    await webhook.execute()
+
+
+async def main():
+    await asyncio.gather(
+        send_webhook('Async webhook message 1'),
+        send_webhook('Async webhook message 2'),
+    )  # sends both messages asynchronously
+
+
+asyncio.run(main())
+```

--- a/discord_webhook/__init__.py
+++ b/discord_webhook/__init__.py
@@ -1,3 +1,4 @@
-__all__ = ["DiscordWebhook", "DiscordEmbed"]
+__all__ = ["DiscordWebhook", "DiscordEmbed", "AsyncDiscordWebhook"]
 
 from .webhook import DiscordWebhook, DiscordEmbed
+from .async_webhook import AsyncDiscordWebhook

--- a/discord_webhook/async_webhook.py
+++ b/discord_webhook/async_webhook.py
@@ -1,9 +1,9 @@
 import asyncio
 import json
 import logging
-from contextlib import contextmanager, asynccontextmanager
+from contextlib import asynccontextmanager
 
-from discord_webhook import DiscordWebhook
+from . import DiscordWebhook
 
 logger = logging.getLogger(__name__)
 

--- a/discord_webhook/async_webhook.py
+++ b/discord_webhook/async_webhook.py
@@ -1,0 +1,202 @@
+import asyncio
+import json
+import logging
+from contextlib import contextmanager, asynccontextmanager
+
+from discord_webhook import DiscordWebhook
+
+logger = logging.getLogger(__name__)
+
+try:
+    import httpx  # noqa
+except ImportError:  # pragma: nocover
+    # Async is an optional dependency so don't raise
+    # an exception unless the AsyncDiscordWebhook is used.
+    pass
+
+
+class AsyncDiscordWebhook(DiscordWebhook):
+    """
+    Async version of DiscordWebhook.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            import httpx  # noqa
+        except ImportError:  # pragma: nocover
+            raise ImportError(
+                "You're attempting to use the async version of discord-webhooks but didn't"
+                " install it using `pip install discord-webhook[async]`."
+            ) from None
+
+    @property
+    @asynccontextmanager
+    async def http_client(self):
+        """
+        A property that returns an httpx.AsyncClient instance that is used for a 'with' statement.
+        Example:
+            async with self.http_client as client:
+                client.post(url, data=data)
+        It will automatically close the client when the context is exited.
+        :return: httpx.AsyncClient
+        """
+        client = httpx.AsyncClient(proxies=self.proxies)
+        yield client
+        await client.aclose()
+
+    async def api_post_request(self, url):
+        async with self.http_client as client:  # type: httpx.AsyncClient
+            if bool(self.files) is False:
+                response = await client.post(url, json=self.json,
+                                             params={'wait': True},
+                                             timeout=self.timeout)
+            else:
+                self.files["payload_json"] = (None, json.dumps(self.json))
+                response = await client.post(url, files=self.files,
+                                             timeout=self.timeout)
+        return response
+
+    async def execute(self, remove_embeds=False, remove_files=False):
+        """
+        executes the Webhook
+        :param remove_embeds: if set to True, calls `self.remove_embeds()` to empty `self.embeds` after webhook is executed
+        :param remove_files: if set to True, calls `self.remove_files()` to empty `self.files` after webhook is executed
+        :return: Webhook response
+        """
+        webhook_urls = self.url if isinstance(self.url, list) else [self.url]
+        urls_len = len(webhook_urls)
+        responses = []
+        for i, url in enumerate(webhook_urls):
+            response = await self.api_post_request(url)
+            if response.status_code in [200, 204]:
+                logger.debug(
+                    "[{index}/{length}] Webhook executed".format(
+                        index=i + 1, length=urls_len
+                    )
+                )
+            elif response.status_code == 429 and self.rate_limit_retry:
+                while response.status_code == 429:
+                    await self.handle_rate_limit(response)
+                    response = await self.api_post_request(url)
+                    if response.status_code in [200, 204]:
+                        logger.debug(
+                            "[{index}/{length}] Webhook executed".format(
+                                index=i + 1, length=urls_len
+                            )
+                        )
+                        break
+            else:
+                logger.error(
+                    "[{index}/{length}] Webhook status code {status_code}: {content}".format(
+                        index=i + 1,
+                        length=urls_len,
+                        status_code=response.status_code,
+                        content=response.content.decode("utf-8"),
+                    )
+                )
+            responses.append(response)
+        if remove_embeds:
+            self.remove_embeds()
+        if remove_files:
+            self.remove_files()
+        return responses[0] if len(responses) == 1 else responses
+
+    async def edit(self, sent_webhook):
+        """
+        edits the webhook passed as a response
+        :param sent_webhook: webhook.execute() response
+        :return: Another webhook response
+        """
+        sent_webhook = sent_webhook if isinstance(sent_webhook, list) else [sent_webhook]
+        webhook_len = len(sent_webhook)
+        responses = []
+        async with self.http_client as client:  # type: httpx.AsyncClient
+            for i, webhook in enumerate(sent_webhook):
+                previous_sent_message_id = json.loads(webhook.content.decode('utf-8'))['id']
+                url = webhook.url.split('?')[0] + '/messages/' + str(previous_sent_message_id)  # removes any query params
+                if bool(self.files) is False:
+                    patch_kwargs = {'json': self.json, 'params': {'wait': True}, 'timeout': self.timeout}
+                else:
+                    self.files["payload_json"] = (None, json.dumps(self.json))
+                    patch_kwargs = {'files': self.files, 'timeout': self.timeout}
+                response = await client.patch(url, **patch_kwargs)
+                if response.status_code in [200, 204]:
+                    logger.debug(
+                        "[{index}/{length}] Webhook edited".format(
+                            index=i + 1,
+                            length=webhook_len,
+                        )
+                    )
+                elif response.status_code == 429 and self.rate_limit_retry:
+                    while response.status_code == 429:
+                        await self.handle_rate_limit(response)
+                        response = await client.patch(url, **patch_kwargs)
+                        if response.status_code in [200, 204]:
+                            logger.debug(
+                                "[{index}/{length}] Webhook edited".format(
+                                    index=i + 1,
+                                    length=webhook_len,
+                                )
+                            )
+                            break
+                else:
+                    logger.error(
+                        "[{index}/{length}] Webhook status code {status_code}: {content}".format(
+                            index=i + 1,
+                            length=webhook_len,
+                            status_code=response.status_code,
+                            content=response.content.decode("utf-8"),
+                        )
+                    )
+                responses.append(response)
+        return responses[0] if len(responses) == 1 else responses
+
+    async def delete(self, sent_webhook):
+        """
+        deletes the webhook passed as a response
+        :param sent_webhook: webhook.execute() response
+        :return: Response
+        """
+        sent_webhook = sent_webhook if isinstance(sent_webhook, list) else [sent_webhook]
+        webhook_len = len(sent_webhook)
+        responses = []
+        async with self.http_client as client:  # type: httpx.AsyncClient
+            for i, webhook in enumerate(sent_webhook):
+                url = webhook.url.split('?')[0]  # removes any query params
+                previous_sent_message_id = json.loads(webhook.content.decode('utf-8'))['id']
+                response = await client.delete(url + '/messages/' + str(previous_sent_message_id), timeout=self.timeout)
+                if response.status_code in [200, 204]:
+                    logger.debug(
+                        "[{index}/{length}] Webhook deleted".format(
+                            index=i + 1,
+                            length=webhook_len,
+                        )
+                    )
+                else:
+                    logger.error(
+                        "[{index}/{length}] Webhook status code {status_code}: {content}".format(
+                            index=i + 1,
+                            length=webhook_len,
+                            status_code=response.status_code,
+                            content=response.content.decode("utf-8"),
+                        )
+                    )
+                responses.append(response)
+        return responses[0] if len(responses) == 1 else responses
+
+    async def handle_rate_limit(self, response):
+        """
+        handles the rate limit
+        :param response: Response
+        :return: Response
+        """
+        errors = response.json()
+        wh_sleep = (int(errors['retry_after']) / 1000) + 0.15
+        await asyncio.sleep(wh_sleep)
+        logger.error(
+            "Webhook rate limited: sleeping for {wh_sleep} "
+            "seconds...".format(
+                wh_sleep=wh_sleep
+            )
+        )

--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -3,7 +3,7 @@ import json
 import time
 import datetime
 import requests
-from webhook_exceptions import *
+from .webhook_exceptions import *
 
 logger = logging.getLogger(__name__)
 

--- a/examples/use_async.py
+++ b/examples/use_async.py
@@ -1,0 +1,20 @@
+import asyncio
+
+from discord_webhook import AsyncDiscordWebhook
+
+
+async def send_webhook(message):
+    webhook = AsyncDiscordWebhook(url='your webhook url',
+                                  content=message)
+    await webhook.execute()
+
+
+async def main():
+    await asyncio.gather(
+        send_webhook('Async webhook message 1'),
+        send_webhook('Async webhook message 2'),
+    )  # sends both messages asynchronously
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flake8==3.9.2
 pyflakes==2.3.1
 pylint==2.8.3
 requests==2.25.1
+httpx>=0.20.0

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,11 @@ setup(
     install_requires=[
             'requests>=2.19.1',
     ],
+    extras_require={
+        'async': [
+            'httpx>=0.20.0'
+        ]
+    },
     author='Vadim Zifra',
     author_email='vadim@minehub.de',
     classifiers=[


### PR DESCRIPTION
Added async support, as mentioned in issue #30.

It uses [httpx](https://github.com/encode/httpx/) to send requests asynchronously, but I set it up so that unless users plan to utilize the async functionality, they will not be required to install it.

To use the async features, the user would install the package using:
```
pip install discord-webhook[async]
```