### PR TITLE
Fix support for using a list of webhook URLs

### DIFF
--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -399,6 +399,7 @@ class DiscordWebhook:
         :param remove_files: if set to True, calls `self.remove_files()` to empty `self.files` after webhook is executed
         :return: Webhook response
         """
+        webhook_urls = self.url
         if isinstance(self.url, str):
             webhook_urls = [self.url]
         urls_len = len(webhook_urls)


### PR DESCRIPTION
Hello. I'm using this library in a project called [Planefence](github.com/kx1t/docker-planefence)

One of our users reported an exception when sending a webhook. It looks like a recent change broke sending a list of URLs to the library.

The code used to handle that fine:
```
        webhook_urls = self.url if isinstance(self.url, list) else [self.url]
        urls_len = len(webhook_urls)
```
It would assign our list of URLs to `webhook_urls`, but now it looks like this:
```
        if isinstance(self.url, str):
            webhook_urls = [self.url]
        urls_len = len(webhook_urls)
```
So if you don't send it a single string it doesn't define `webhook_urls` and breaks.

This resolves that by assigning `this.url` to `webhook_urls` and then letting the conditional override that definition if the value is a string.

Thanks for the awesome library!