### PR TITLE
fix async file attachments (lovvskillz/python-discord-webhook#88)

### DIFF
--- a/discord_webhook/async_webhook.py
+++ b/discord_webhook/async_webhook.py
@@ -52,7 +52,7 @@ class AsyncDiscordWebhook(DiscordWebhook):
                                              params={'wait': True},
                                              timeout=self.timeout)
             else:
-                self.files["payload_json"] = (None, json.dumps(self.json))
+                self.files["payload_json"] = (None, json.dumps(self.json).encode('utf-8'))
                 response = await client.post(url, files=self.files,
                                              timeout=self.timeout)
         return response


### PR DESCRIPTION
Since httpx does not allow string content in files, simply encoding the JSON attachment fixes the issue