### PR TITLE
Fixed `retry_after` handling

### DIFF
--- a/discord_webhook/async_webhook.py
+++ b/discord_webhook/async_webhook.py
@@ -77,12 +77,8 @@ class AsyncDiscordWebhook(DiscordWebhook):
             errors = response.json()
             if not response.headers.get("Via"):
                 raise HTTPException(errors)
-            wh_sleep = int(errors["retry_after"]) + 0.15
-            logger.error(
-                "Webhook rate limited: sleeping for {wh_sleep} seconds...".format(
-                    wh_sleep=wh_sleep
-                )
-            )
+            wh_sleep = float(errors["retry_after"]) + 0.15
+            logger.error(f"Webhook rate limited: sleeping for {wh_sleep:.2f} seconds...")
             await asyncio.sleep(wh_sleep)
             response = await request()
             if response.status_code in [200, 204]:

--- a/discord_webhook/async_webhook.py
+++ b/discord_webhook/async_webhook.py
@@ -78,7 +78,9 @@ class AsyncDiscordWebhook(DiscordWebhook):
             if not response.headers.get("Via"):
                 raise HTTPException(errors)
             wh_sleep = float(errors["retry_after"]) + 0.15
-            logger.error(f"Webhook rate limited: sleeping for {wh_sleep:.2f} seconds...")
+            logger.error(
+                f"Webhook rate limited: sleeping for {wh_sleep:.2f} seconds..."
+            )
             await asyncio.sleep(wh_sleep)
             response = await request()
             if response.status_code in [200, 204]:

--- a/discord_webhook/async_webhook.py
+++ b/discord_webhook/async_webhook.py
@@ -77,7 +77,7 @@ class AsyncDiscordWebhook(DiscordWebhook):
             errors = response.json()
             if not response.headers.get("Via"):
                 raise HTTPException(errors)
-            wh_sleep = (int(errors["retry_after"]) / 1000) + 0.15
+            wh_sleep = int(errors["retry_after"]) + 0.15
             logger.error(
                 "Webhook rate limited: sleeping for {wh_sleep} seconds...".format(
                     wh_sleep=wh_sleep

--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -447,7 +447,9 @@ class DiscordWebhook:
             if not response.headers.get("Via"):
                 raise HTTPException(errors)
             wh_sleep = float(errors["retry_after"]) + 0.15
-            logger.error(f"Webhook rate limited: sleeping for {wh_sleep:.2f} seconds...")
+            logger.error(
+                f"Webhook rate limited: sleeping for {wh_sleep:.2f} seconds..."
+            )
             time.sleep(wh_sleep)
             response = request()
             if response.status_code in [200, 204]:

--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -446,7 +446,7 @@ class DiscordWebhook:
             errors = json.loads(response.content.decode("utf-8"))
             if not response.headers.get("Via"):
                 raise HTTPException(errors)
-            wh_sleep = (int(errors["retry_after"]) / 1000) + 0.15
+            wh_sleep = int(errors["retry_after"]) + 0.15
             logger.error(f"Webhook rate limited: sleeping for {wh_sleep} seconds...")
             time.sleep(wh_sleep)
             response = request()

--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -446,8 +446,8 @@ class DiscordWebhook:
             errors = json.loads(response.content.decode("utf-8"))
             if not response.headers.get("Via"):
                 raise HTTPException(errors)
-            wh_sleep = int(errors["retry_after"]) + 0.15
-            logger.error(f"Webhook rate limited: sleeping for {wh_sleep} seconds...")
+            wh_sleep = float(errors["retry_after"]) + 0.15
+            logger.error(f"Webhook rate limited: sleeping for {wh_sleep:.2f} seconds...")
             time.sleep(wh_sleep)
             response = request()
             if response.status_code in [200, 204]:


### PR DESCRIPTION
The `retry_after` field in the response is in seconds, but we're currently handling it as if it's milliseconds.