### PR TITLE
Fix bug in handle_rate_limit

### DIFF
--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -402,7 +402,7 @@ class DiscordWebhook:
             errors = json.loads(response.content.decode("utf-8"))
             if not response.headers.get("Via"):
                 raise HTTPException(errors)
-            wh_sleep = (int(errors["retry_after"]) / 1000) + 0.15
+            wh_sleep = float(errors["retry_after"]) + 0.15
             logger.error(f"Webhook rate limited: sleeping for {wh_sleep} seconds...")
             time.sleep(wh_sleep)
             response = request()


### PR DESCRIPTION
https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit

According to this document, "retry_after" is the number of seconds in float.

This should prevent getting temporary bans.

Fixes #134