### PR TITLE
Use anyio to support both trio and asyncio

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     rev: 22.8.0
     hooks:
       - id: black
-        language_version: python3
+        language_version: python3.10
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.272
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     rev: 22.8.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.272
     hooks:

--- a/README.md
+++ b/README.md
@@ -349,25 +349,41 @@ In order to use the async version, you need to install the package using:
 ```
 pip install discord-webhook[async]
 ```
+python-discord-webhook supports both asyncio and [trio](https://trio.readthedocs.io/en/stable/) through the use of [anyio](https://anyio.readthedocs.io/en/3.x/)
+
 Example usage:
 ```python
 import asyncio
-from discord_webhook import AsyncDiscordWebhook
+import os
+
+import trio
+
+import discord_webhook
 
 
-async def send_webhook(message):
-    webhook = AsyncDiscordWebhook(url="your webhook url", content=message)
+async def send_webhook(message: str):
+    url = os.getenv("TEST_WEBHOOK_URL")
+    webhook = discord_webhook.AsyncDiscordWebhook(url=url, content=message)
     await webhook.execute()
 
 
-async def main():
+async def trio_main():
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(send_webhook, "Async webhook message 1")
+        nursery.start_soon(send_webhook, "Async webhook message 2")
+
+
+async def asyncio_main():
     await asyncio.gather(
         send_webhook("Async webhook message 1"),
         send_webhook("Async webhook message 2"),
     )  # sends both messages asynchronously
 
 
-asyncio.run(main())
+if __name__ == "__main__":
+    trio.run(trio_main)
+    asyncio.run(asyncio_main())
+
 ```
 
 ### Use CLI

--- a/README.md
+++ b/README.md
@@ -362,8 +362,7 @@ import discord_webhook
 
 
 async def send_webhook(message: str):
-    url = os.getenv("TEST_WEBHOOK_URL")
-    webhook = discord_webhook.AsyncDiscordWebhook(url=url, content=message)
+    webhook = discord_webhook.AsyncDiscordWebhook(url="your webhook url", content=message)
     await webhook.execute()
 
 
@@ -383,6 +382,7 @@ async def asyncio_main():
 if __name__ == "__main__":
     trio.run(trio_main)
     asyncio.run(asyncio_main())
+
 
 ```
 

--- a/discord_webhook/async_webhook.py
+++ b/discord_webhook/async_webhook.py
@@ -1,4 +1,4 @@
-import asyncio
+import anyio
 import json
 import logging
 from contextlib import asynccontextmanager
@@ -90,7 +90,7 @@ class AsyncDiscordWebhook(DiscordWebhook):
                     wh_sleep=round(wh_sleep, 2)
                 )
             )
-            await asyncio.sleep(wh_sleep)
+            await anyio.sleep(wh_sleep)
             response = await request()
             if response.status_code in [200, 204]:
                 return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ keywords = ["discord", "webhook"]
 python = "^3.8"
 requests = "^2.28.1"
 httpx = { version = "^0.23.0", optional = true }
+anyio = "^3.7.1"
 
 [tool.poetry.extras]
 async = ["httpx"]


### PR DESCRIPTION
Adds [anyio](https://anyio.readthedocs.io/en/3.x/) to allow the use of both [trio](https://trio.readthedocs.io/en/stable/) and `asyncio` by package users.

Updates `README.md` to show both `asyncio` and `trio` usage examples.

All tests pass and I used the example code to test it against a real world webhook and it worked fine.