### PR TITLE
raise exception instead of log an error

### DIFF
--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -7,7 +7,7 @@ from http.client import HTTPException
 from typing import Any, Dict, List, Optional, Tuple, Union
 import requests
 
-from .webhook_exceptions import ColorNotInRangeException
+from .webhook_exceptions import ColorNotInRangeException, DiscordException
 
 logger = logging.getLogger(__name__)
 
@@ -448,7 +448,7 @@ class DiscordWebhook:
             response = self.handle_rate_limit(response, self.api_post_request)
             logger.debug("Webhook executed")
         else:
-            logger.error(
+            raise DiscordException(
                 "Webhook status code {status_code}: {content}".format(
                     status_code=response.status_code,
                     content=response.content.decode("utf-8"),

--- a/discord_webhook/webhook_exceptions.py
+++ b/discord_webhook/webhook_exceptions.py
@@ -16,3 +16,12 @@ class ColorNotInRangeException(Exception):
                 " (HEXADECIMAL)."
             )
         super().__init__(message)
+
+class DiscordException(Exception):
+    """
+    This Exception is throw as a generic error from discord's API.
+    """
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+        


### PR DESCRIPTION
Hi,

This is just a suggestion, and this might not be ideal as it changes existing error handling functionality.

I would like to handle the errors, from the library, and not have the library log an error. This is so that I get a stack trace, and can fix the error, rather than have a short confusing discord error I'm finding hard to debug

I like how the library handles rate limiting many requests

Thanks
