### PR TITLE
`proxies` parameter in httpx has been replaced with `proxy`

### DIFF
--- a/discord_webhook/async_webhook.py
+++ b/discord_webhook/async_webhook.py
@@ -43,7 +43,7 @@ class AsyncDiscordWebhook(DiscordWebhook):
         It will automatically close the client when the context is exited.
         :return: httpx.AsyncClient
         """
-        client = httpx.AsyncClient(proxies=self.proxies)
+        client = httpx.AsyncClient(proxy=self.proxies)
         yield client
         await client.aclose()
 


### PR DESCRIPTION
https://github.com/lovvskillz/python-discord-webhook/issues/159