### PR TITLE
Handle hex color codes with leading '#'

### DIFF
--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -111,7 +111,7 @@ class DiscordEmbed:
         Set the color of the embed.
         :param color: color code as decimal(int) or hex(string)
         """
-        self.color = int(color, 16) if isinstance(color, str) else color
+        self.color = int(color.lstrip("#"), 16) if isinstance(color, str) else color
         if self.color is not None and self.color not in range(16777216):
             raise ColorNotInRangeException(color)
 

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -60,6 +60,7 @@ def test__set_embed__timestamp(embed, timestamp):
 @pytest.mark.parametrize(
     "color, output",
     [
+        ("#03b2f8", 242424),
         ("03b2f8", 242424),
         (333333, 333333),
     ],


### PR DESCRIPTION
I always forget to remove the leading '#' from hex color codes so this fixes that.