### PR TITLE
Allow requests version 2.32.1 or higher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## development
 
+### 🩹 Fixes
+- fix version constraint about request==2.32.0
+
 ## 2025-03-04 1.4.0
 
 ### 🎉 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["discord", "webhook"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-requests = "2.32.0"
+requests = "^2.32.0"
 httpx = { version = "^0.28.1", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
dependencies settings of v1.4.0 enforce requests==2.32.0, and it can cause problem other dependencies.

### Note
I suggest that add `poetry.lock` file in repository. [see this docs](https://python-poetry.org/docs/basic-usage/#committing-your-poetrylock-file-to-version-control)