### PR TITLE
Fix 204 handling

### DIFF
--- a/discord_webhook/async_webhook.py
+++ b/discord_webhook/async_webhook.py
@@ -116,8 +116,9 @@ class AsyncDiscordWebhook(DiscordWebhook):
         if remove_embeds:
             self.remove_embeds()
         self.remove_files(clear_attachments=False)
-        if webhook_id := json.loads(response.content.decode("utf-8")).get("id"):
-            self.id = webhook_id
+        if response.content:  # don't parse if response has no content (204 response code)
+            if webhook_id := json.loads(response.content.decode("utf-8")).get("id"):
+                self.id = webhook_id
         return response
 
     async def edit(self) -> "httpx.Response":

--- a/discord_webhook/webhook.py
+++ b/discord_webhook/webhook.py
@@ -470,11 +470,12 @@ class DiscordWebhook:
         if remove_embeds:
             self.remove_embeds()
         self.remove_files(clear_attachments=False)
-        response_content = json.loads(response.content.decode("utf-8"))
-        if webhook_id := response_content.get("id"):
-            self.id = webhook_id
-        if attachments := response_content.get("attachments"):
-            self.attachments = attachments
+        if response.content:  # don't parse if response has no content (204 response code)
+            response_content = json.loads(response.content.decode("utf-8"))
+            if webhook_id := response_content.get("id"):
+                self.id = webhook_id
+            if attachments := response_content.get("attachments"):
+                self.attachments = attachments
         return response
 
     def edit(self) -> "requests.Response":


### PR DESCRIPTION
Currently, `execute` has logic that considers the 204 response code an indicator of a successful send.

But, later in the method, it tries to parse the response body as JSON. If the response is a 204, the response body would be empty, resulting in a JSON parsing exception.

I've added handling so it avoids trying to parse the response if the response content is empty.